### PR TITLE
FourMc: automatic executor-parallel slice expansion for planning

### DIFF
--- a/src/main/scala/org/apache/spark/sql/fourmc/FourMcFileDataSource.scala
+++ b/src/main/scala/org/apache/spark/sql/fourmc/FourMcFileDataSource.scala
@@ -6,7 +6,6 @@ import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.sql.execution.datasources.text.TextFileFormat
 import org.apache.spark.sql.execution.datasources.v2.FileDataSourceV2
 import org.apache.spark.sql.sources.DataSourceRegister
-import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /**
@@ -111,29 +110,5 @@ class FourMcFileDataSource
       if (lastSlash >= 0 && lastSlash < first.length - 1) first.substring(lastSlash + 1)
       else first
     }
-  }
-
-  /**
-   * Returns a table with a user‑provided schema.  Spark calls this method
-   * when the schema is specified explicitly by the user.  We construct
-   * a [[FourMcTable]] with the provided schema so that Spark can skip
-   * inference.  Partitioning and properties are unused for this
-   * simple read‑only source.
-   */
-  override def getTable(
-      options: CaseInsensitiveStringMap,
-      schema: StructType): Table = {
-    val paths = parsePaths(options)
-    require(paths.nonEmpty, "Option 'path' or 'paths' must be specified for fourmc datasource")
-    val cleaned = dropPathOptions(options)
-    val tableName = computeTableName(paths)
-    FourMcTable(
-      name = tableName,
-      sparkSession = SparkSession.active,
-      options = cleaned,
-      paths = paths,
-      userSpecifiedSchema = Some(schema),
-      fallbackFileFormat = fallbackFileFormat
-    )
   }
 }

--- a/src/main/scala/org/apache/spark/sql/fourmc/FourMcParallelPlanner.scala
+++ b/src/main/scala/org/apache/spark/sql/fourmc/FourMcParallelPlanner.scala
@@ -1,0 +1,39 @@
+package org.apache.spark.sql.fourmc
+
+import org.apache.spark.SparkContext
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.datasources.PartitionedFile
+import org.apache.spark.util.SerializableConfiguration
+
+/**
+ * Parallel expansion of 4mc block-aligned slices using Spark executors.
+ * Only slice bounds are returned to the driver to avoid shipping Catalyst rows.
+ */
+object FourMcParallelPlanner {
+
+  final case class Slice(path: String, start: Long, length: Long) extends Serializable
+
+  def expandWithSparkJob(
+      sc: SparkContext,
+      files: Seq[(String, Long)],
+      confBroadcast: Broadcast[SerializableConfiguration],
+      maxSplitBytes: Long,
+      parallelismMax: Int
+  ): Seq[Slice] = {
+    if (files.isEmpty) return Seq.empty
+    val numTasks = math.min(files.size, math.max(1, parallelismMax))
+    val rdd = sc.parallelize(files, numTasks)
+    val slices = rdd.mapPartitions { iter =>
+      iter.flatMap { case (path, len) =>
+        // Use empty partition values and hosts; they're reconstructed on the driver
+        val base = PartitionedFile(InternalRow(Array.empty), path, 0L, len, Array.empty[String])
+        FourMcBlockPlanner
+          .expandPartitionedFile(base, maxSplitBytes, confBroadcast)
+          .map(pf => Slice(pf.filePath, pf.start, pf.length))
+      }
+    }.collect()
+    slices.toSeq
+  }
+}
+

--- a/src/main/scala/org/apache/spark/sql/fourmc/FourMcParallelPlanner.scala
+++ b/src/main/scala/org/apache/spark/sql/fourmc/FourMcParallelPlanner.scala
@@ -7,8 +7,17 @@ import org.apache.spark.sql.execution.datasources.PartitionedFile
 import org.apache.spark.util.SerializableConfiguration
 
 /**
- * Parallel expansion of 4mc block-aligned slices using Spark executors.
- * Only slice bounds are returned to the driver to avoid shipping Catalyst rows.
+ * Parallel expansion of 4mc block‑aligned slices using Spark executors.
+ *
+ * This mirrors Spark's pattern in `org.apache.spark.util.HadoopFSUtils.parallelListLeafFiles`:
+ * when many inputs are present, launch a Spark job from the driver and fan out work across
+ * partitions. Each task uses FourMcBlockPlanner.expandPartitionedFile to compute block‑aligned
+ * slice boundaries. Only `(path, start, length)` are returned to the driver to avoid shipping
+ * Catalyst rows or Hadoop configuration back.
+ *
+ * Notes
+ * - Caller reconstructs `PartitionedFile` on the driver (partition values and host locations).
+ * - Sets a user‑friendly Spark job description for UI/debugging and restores the previous one.
  */
 object FourMcParallelPlanner {
 
@@ -24,16 +33,30 @@ object FourMcParallelPlanner {
     if (files.isEmpty) return Seq.empty
     val numTasks = math.min(files.size, math.max(1, parallelismMax))
     val rdd = sc.parallelize(files, numTasks)
-    val slices = rdd.mapPartitions { iter =>
-      iter.flatMap { case (path, len) =>
-        // Use empty partition values and hosts; they're reconstructed on the driver
-        val base = PartitionedFile(InternalRow(Array.empty), path, 0L, len, Array.empty[String])
-        FourMcBlockPlanner
-          .expandPartitionedFile(base, maxSplitBytes, confBroadcast)
-          .map(pf => Slice(pf.filePath, pf.start, pf.length))
-      }
-    }.collect()
+
+    // Set a concise job description, similar to HadoopFSUtils
+    val previous = sc.getLocalProperty(SparkContext.SPARK_JOB_DESCRIPTION)
+    val desc = files.size match {
+      case 0 => "FourMc: expand slices for 0 files"
+      case 1 => s"FourMc: expand slices for 1 file:<br/>${files.head._1}"
+      case n => s"FourMc: expand slices for $n files:<br/>${files.head._1}, ..."
+    }
+
+    val slices = try {
+      sc.setJobDescription(desc)
+      rdd.mapPartitions { iter =>
+        iter.flatMap { case (path, len) =>
+          // Use empty partition values and hosts; they're reconstructed on the driver
+          val base = PartitionedFile(InternalRow.empty, path, 0L, len, Array.empty[String])
+          FourMcBlockPlanner
+            .expandPartitionedFile(base, maxSplitBytes, confBroadcast)
+            .map(pf => Slice(pf.filePath, pf.start, pf.length))
+        }
+      }.collect()
+    } finally {
+      sc.setJobDescription(previous)
+    }
+
     slices.toSeq
   }
 }
-

--- a/src/main/scala/org/apache/spark/sql/fourmc/FourMcScan.scala
+++ b/src/main/scala/org/apache/spark/sql/fourmc/FourMcScan.scala
@@ -3,15 +3,17 @@ package org.apache.spark.sql.fourmc
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.read.{Batch, PartitionReaderFactory, Scan, ScanBuilder}
 import org.apache.spark.sql.execution.PartitionedFileUtil
-import org.apache.spark.sql.execution.datasources.FilePartition
 import org.apache.spark.sql.execution.datasources.v2.FileScan
+import org.apache.spark.sql.execution.datasources.{FilePartition, PartitionedFile}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.SerializableConfiguration
 
 import java.util.Locale
+import scala.collection.mutable
 
 /**
  * Builder for 4mc scans.  Similar to CSVScanBuilder, it accepts Spark's
@@ -109,6 +111,15 @@ final class FourMcScan(
 
   // Match FileScan's case-sensitivity and name normalization logic
   private val isCaseSensitive = sparkSession.sessionState.conf.caseSensitiveAnalysis
+  // Parallel expand configuration (defaults to Spark's discovery settings)
+  private val parallelExpandEnabled: Boolean =
+    java.lang.Boolean.parseBoolean(options.getOrDefault("fourmc.parallelExpand.enabled", "true"))
+  private val parallelExpandThreshold: Int =
+    Option(options.get("fourmc.parallelExpand.threshold")).map(_.toInt)
+      .getOrElse(sparkSession.sessionState.conf.parallelPartitionDiscoveryThreshold)
+  private val parallelExpandMax: Int =
+    Option(options.get("fourmc.parallelExpand.maxParallelism")).map(_.toInt)
+      .getOrElse(sparkSession.sessionState.conf.parallelPartitionDiscoveryParallelism)
 
   /**
    * Human-readable description used in the query plan.  This appears in the
@@ -146,21 +157,63 @@ final class FourMcScan(
       org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
         .generate(readPartitionAttributes, partitionAttributes)
 
-    val conf = broadcastConf.value.value
-    val splitFiles = selectedPartitions.flatMap { partition =>
-      // Prune partition values if part of the partition columns are not required.
-      val partitionValues = if (readPartitionAttributes != partitionAttributes) {
-        partitionValueProject(partition.values).copy()
-      } else {
-        partition.values
+    val allFiles = selectedPartitions.flatMap(_.files)
+    val useParallel = parallelExpandEnabled && allFiles.size >= parallelExpandThreshold
+
+    val splitFiles: Seq[PartitionedFile] = if (useParallel) {
+      // Map each file path to its partition values
+      val partValuesByPath = mutable.HashMap.empty[String, org.apache.spark.sql.catalyst.InternalRow]
+      // Cache preferred hosts per file path using Spark's helper
+      val hostsByPath = mutable.HashMap.empty[String, Array[String]]
+      selectedPartitions.foreach { partition =>
+        val pvalues = if (readPartitionAttributes != partitionAttributes) {
+          partitionValueProject(partition.values).copy()
+        } else partition.values
+        partition.files.foreach { f =>
+          val pStr = f.getPath.toUri.toString
+          // Cache only meaningful partition values (non-empty row)
+          if (pvalues.numFields > 0) {
+            partValuesByPath.update(pStr, pvalues)
+          }
+          val base = PartitionedFileUtil.getPartitionedFile(f, f.getPath, pvalues)
+          // Cache only non-empty preferred locations
+          val locs = base.locations
+          if (locs != null && locs.nonEmpty) {
+            hostsByPath.update(pStr, locs)
+          }
+        }
       }
-      partition.files.flatMap { file =>
-        val filePath = file.getPath
-        // Build a single PartitionedFile for the whole file (with proper hosts)
-        val base = PartitionedFileUtil.getPartitionedFile(file, filePath, partitionValues)
-        // Expand it into 4mc block-aligned slices using the helper
-        FourMcBlockPlanner
-          .expandPartitionedFile(base, maxSplitBytes, broadcastConf)
+      // Prepare (path, len) pairs
+      val pairs = allFiles.map(f => (f.getPath.toUri.toString, f.getLen))
+      val slices = FourMcParallelPlanner.expandWithSparkJob(
+        sparkSession.sparkContext,
+        pairs,
+        broadcastConf,
+        maxSplitBytes,
+        parallelExpandMax
+      )
+      val empty = InternalRow(Array.empty)
+      slices.iterator.map { s =>
+        val pv = partValuesByPath.getOrElse(s.path, empty)
+        val hosts = hostsByPath.getOrElse(s.path, Array.empty[String])
+        PartitionedFile(pv, s.path, s.start, s.length, hosts)
+      }.toSeq.sortBy(_.length)(implicitly[Ordering[Long]].reverse)
+    } else {
+      selectedPartitions.flatMap { partition =>
+        // Prune partition values if part of the partition columns are not required.
+        val partitionValues = if (readPartitionAttributes != partitionAttributes) {
+          partitionValueProject(partition.values).copy()
+        } else {
+          partition.values
+        }
+        partition.files.flatMap { file =>
+          val filePath = file.getPath
+          // Build a single PartitionedFile for the whole file (with proper hosts)
+          val base = PartitionedFileUtil.getPartitionedFile(file, filePath, partitionValues)
+          // Expand it into 4mc block-aligned slices using the helper
+          FourMcBlockPlanner
+            .expandPartitionedFile(base, maxSplitBytes, broadcastConf)
+        }
       }.toArray.sortBy(_.length)(implicitly[Ordering[Long]].reverse)
     }
 
@@ -232,7 +285,7 @@ object FourMcBlockPlanner {
       return Seq(pf.copy(start = 0L, length = fileLen))
     }
     val blocks = index.getNumberOfBlocks
-    val out = scala.collection.mutable.ArrayBuffer[PartitionedFile]()
+    val out = mutable.ArrayBuffer[PartitionedFile]()
     var i = 0
     while (i < blocks) {
       val start = if (i == 0) 0L else index.getPosition(i)

--- a/src/main/scala/org/apache/spark/sql/fourmc/FourMcScan.scala
+++ b/src/main/scala/org/apache/spark/sql/fourmc/FourMcScan.scala
@@ -4,7 +4,7 @@ import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.connector.read.{Batch, PartitionReaderFactory, Scan, ScanBuilder}
+import org.apache.spark.sql.connector.read._
 import org.apache.spark.sql.execution.PartitionedFileUtil
 import org.apache.spark.sql.execution.datasources.v2.FileScan
 import org.apache.spark.sql.execution.datasources.{FilePartition, PartitionedFile}
@@ -36,7 +36,7 @@ import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
 final class FourMcScanBuilder(
     spark: SparkSession,
     fileIndex: PartitioningAwareFileIndex,
-    options: CaseInsensitiveStringMap
+    val options: CaseInsensitiveStringMap
 ) extends ScanBuilder {
 
   // Determine whether to include the offset column.  We re-compute the data
@@ -46,7 +46,7 @@ final class FourMcScanBuilder(
 
   import org.apache.spark.sql.types.{LongType, StringType, StructField}
 
-  override def build(): Scan = {
+  override lazy val build: Scan = {
     val resolvedSchema = if (withOffset) {
       // When the offset column is requested, return a two-column schema:
       // (offset LONG, value STRING).
@@ -141,7 +141,7 @@ final class FourMcScan(
    * footer index, then coalesce those slices back into FilePartitions using
    * Spark's helper to balance task sizes.
    */
-  override def partitions: Seq[FilePartition] = {
+  override lazy val planInputPartitions: Array[InputPartition] = {
     // This inlines FileScan.partitions and replaces file splitting with 4mc-aware expansion.
     val selectedPartitions = fileIndex.listFiles(partitionFilters, dataFilters)
     val maxSplitBytes = FilePartition.maxSplitBytes(sparkSession, selectedPartitions)
@@ -217,7 +217,7 @@ final class FourMcScan(
       }.toArray.sortBy(_.length)(implicitly[Ordering[Long]].reverse)
     }
 
-    FilePartition.getFilePartitions(sparkSession, splitFiles, maxSplitBytes)
+    FilePartition.getFilePartitions(sparkSession, splitFiles, maxSplitBytes).toArray
   }
 
   private def normalizeName(name: String): String = if (isCaseSensitive) name else name.toLowerCase(Locale.ROOT)
@@ -279,7 +279,7 @@ object FourMcBlockPlanner {
     val conf = broadcastConf.value.value
     val path = new Path(pf.filePath)
     val fs: FileSystem = path.getFileSystem(conf)
-    val fileLen = fs.getFileStatus(path).getLen
+    val fileLen = pf.length
     val index = FourMcBlockIndex.readIndex(fs, path)
     if (index == null || index.isEmpty) {
       return Seq(pf.copy(start = 0L, length = fileLen))

--- a/src/main/scala/org/apache/spark/sql/fourmc/FourMcTable.scala
+++ b/src/main/scala/org/apache/spark/sql/fourmc/FourMcTable.scala
@@ -3,11 +3,10 @@ package org.apache.spark.sql.fourmc
 import org.apache.hadoop.fs.FileStatus
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.internal.Logging
 import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
 import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.sql.execution.datasources.v2.FileTable
-import org.apache.spark.sql.types.{AtomicType, DataType, StructType, UserDefinedType}
+import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 import scala.annotation.tailrec
@@ -78,9 +77,8 @@ final case class FourMcTable(
    * schema was specified when the table was created, return it; otherwise
    * return None to use the default text schema.
    */
-  override def inferSchema(files: Seq[FileStatus]): Option[StructType] = {
-    userSpecifiedSchema
-  }
+  override def inferSchema(files: Seq[FileStatus]): Option[StructType] =
+    userSpecifiedSchema.orElse(Some(StructType(Array(StructField("value", StringType)))))
 
   /**
    * Determine whether a data type is supported for writing.  Since this

--- a/src/main/scala/org/apache/spark/sql/fourmc/FourMcTable.scala
+++ b/src/main/scala/org/apache/spark/sql/fourmc/FourMcTable.scala
@@ -48,7 +48,7 @@ final case class FourMcTable(
       val before = cachedScanBuilder.options
       val beforeMap = before.entrySet().asScala.map(e => e.getKey -> e.getValue).toMap
       val afterMap = options.entrySet().asScala.map(e => e.getKey -> e.getValue).toMap
-      val allKeys = beforeMap.keySet ++ afterMap.keySet
+      val allKeys = (beforeMap.keySet ++ afterMap.keySet) - "path"
       val diffs = allKeys.flatMap { k =>
         val oldV = beforeMap.getOrElse(k, null)
         val newV = afterMap.getOrElse(k, null)

--- a/src/main/scala/org/apache/spark/sql/fourmc/FourMcTable.scala
+++ b/src/main/scala/org/apache/spark/sql/fourmc/FourMcTable.scala
@@ -3,6 +3,7 @@ package org.apache.spark.sql.fourmc
 import org.apache.hadoop.fs.FileStatus
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
 import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.sql.execution.datasources.v2.FileTable
@@ -10,6 +11,7 @@ import org.apache.spark.sql.types.{AtomicType, DataType, StructType, UserDefined
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 import scala.annotation.tailrec
+import scala.collection.JavaConverters._
 
 /**
  * A concrete FileTable for reading 4mc-compressed files.  This mirrors Spark's
@@ -38,14 +40,36 @@ final case class FourMcTable(
    * partitions based on the 4mc footer block index and create readers
    * accordingly.
    */
-  override def newScanBuilder(options: CaseInsensitiveStringMap): FourMcScanBuilder = {
-    // Pass the partitioning-aware file index to the scan builder.  Spark's
-    // FileTable exposes the file index as a PartitioningAwareFileIndex, which
-    // retains information about partition columns.  We also forward the
-    // remaining options to the builder; the builder will compute the read
-    // schema based on the `withOffset` flag and fetch the partition schema
-    // from the index.
+  private lazy val cachedScanBuilder: FourMcScanBuilder =
     new FourMcScanBuilder(sparkSession, fileIndex, options)
+
+  override def newScanBuilder(options: CaseInsensitiveStringMap): FourMcScanBuilder = {
+    // Sanity check: warn if options differ from the cached builder's options.
+    try {
+      val before = cachedScanBuilder.options
+      val beforeMap = before.entrySet().asScala.map(e => e.getKey -> e.getValue).toMap
+      val afterMap = options.entrySet().asScala.map(e => e.getKey -> e.getValue).toMap
+      val allKeys = beforeMap.keySet ++ afterMap.keySet
+      val diffs = allKeys.flatMap { k =>
+        val oldV = beforeMap.getOrElse(k, null)
+        val newV = afterMap.getOrElse(k, null)
+        val ov = Option(oldV).getOrElse("")
+        val nv = Option(newV).getOrElse("")
+        if (ov != nv) Some(k -> (ov, nv)) else None
+      }
+      if (diffs.nonEmpty) {
+        logWarning("fourmc: newScanBuilder called with changed options; reusing cached builder. Changed entries:")
+        diffs.toSeq.sortBy(_._1).foreach { case (k, (ov, nv)) =>
+          val ovStr = if (ov.nonEmpty) ov else "<unset>"
+          val nvStr = if (nv.nonEmpty) nv else "<unset>"
+          logWarning(s"  $k: old=$ovStr new=$nvStr")
+        }
+      }
+    } catch {
+      case _: Throwable => // be best-effort about logging
+    }
+    // Options are assumed stable for the lifetime of this table; reuse builder.
+    cachedScanBuilder
   }
 
   /**


### PR DESCRIPTION
Summary
- Add executor-parallel slice expansion for planning large inputs.
- Automatically activates above a file-count threshold; returns `(path,start,length)` for driver-side coalescing.
- Cache scan builder and warn when options change between scans.

Activation and tuning
- Enabled by default; activates when file count ≥ session threshold.
- Optional overrides: `fourmc.parallelExpand.threshold`, `fourmc.parallelExpand.maxParallelism`.
- Sets a concise Spark job description during planning for UI clarity.

Other changes
- Minor cleanup in scan/table wiring; small adjustments to schema handling (`inferSchema`) without altering existing behavior.

Validation
- `sbt compile` passes locally.
- Smoke test: ensure 4mc codec on classpath; read a large directory of `.4mc` files and observe executor-side expansion.
